### PR TITLE
Deprecated hook and $settings no longer used the same way.

### DIFF
--- a/emails/woo-preview-emails.php
+++ b/emails/woo-preview-emails.php
@@ -117,34 +117,14 @@ function wordimpress_preview_woo_emails() {
 }
 
 /*
- *    Extend WC_Email_Setting
- *    in order to add our own
- *    links to the preview
+ *    Display Link at beginning of email settings
  */
-add_filter( 'woocommerce_email_settings', 'add_preview_email_links' );
+add_action( 'woocommerce_email_settings_before', 'add_preview_email_links', 1, 0 );
 
-function add_preview_email_links( $settings ) {
-	$updated_settings = array();
-	foreach ( $settings as $section ) {
-		// at the bottom of the General Options section
+function add_preview_email_links() {
 
-		if ( isset( $section['id'] ) && 'email_recipient_options' == $section['id'] &&
-
-		     isset( $section['type'] ) && 'sectionend' == $section['type']
-		) {
-			$updated_settings[] = array(
-				'title' => __( 'Preview Email Templates', 'previewemail' ),
-				'type'  => 'title',
-				'desc'  => __( '<a href="' . site_url() . '/wp-admin/admin-ajax.php?action=previewemail&file=customer-new-account.php" target="_blank">Click Here to preview all of your Email Templates with Orders</a>.', 'previewemail' ),
-				'id'    => 'email_preview_links'
-			);
-		}
-		$updated_settings[] = $section;
-
-	}
-
-	return $updated_settings;
-
+    echo "<h3>" . __( 'Preview Email Templates', 'previewemail' ) . "</h3>";
+    echo __( '<a href="' . site_url() . '/wp-admin/admin-ajax.php?action=previewemail&file=customer-new-account.php" target="_blank">Click Here to preview all of your Email Templates with Orders</a>.', 'previewemail' );
 }
 
 /*


### PR DESCRIPTION
Using version `3.0` I could not find the hook `woocommerce_email_settings` so I replaced the `add_filter` call with `woocommerce_email_settings_before`. Using the new `_before` hook changed what was being passed into the filter. I couldn't connect your original logic to the new filter, so I changed it to an action. Because this new hook is more specific, we _shouldn't_ have to check for the context `email_recipient_options`. Once I got the link displaying on the screen, the preview page still works. Working for me on Woocommerce `3.1.0` and WordPress version `4.8`